### PR TITLE
Allow a 'customHeader' argument to createAppSyncClient to easily add headers to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ const client = new AWSAppSyncClient({
   auth: {
     type: AppSyncConfig.authenticationType,
     apiKey: AppSyncConfig.apiKey,
+    // customHeaders: {"Authorization" : "Bearer 1234"} // optional : these headers will be added to each request 
     // jwtToken: async () => token, // Required when you use Cognito UserPools OR OpenID Connect. token object is obtained previously
   }
 })

--- a/packages/aws-appsync/src/client.ts
+++ b/packages/aws-appsync/src/client.ts
@@ -131,6 +131,7 @@ export interface AWSAppSyncClientOptions {
     cacheOptions?: ApolloReducerConfig,
     disableOffline?: boolean,
     offlineConfig?: OfflineConfig,
+    customHeaders?,
 }
 
 export type OfflineConfig = Pick<Partial<StoreOptions<any>>, 'storage' | 'callback' | 'keyPrefix'> & {
@@ -178,6 +179,7 @@ class AWSAppSyncClient<TCacheShape extends NormalizedCacheObject> extends Apollo
             callback = () => { },
             storeCacheRootMutation = false,
         } = {},
+        customHeaders = {},
     }: AWSAppSyncClientOptions, options?: Partial<ApolloClientOptions<TCacheShape>>) {
         const { cache: customCache = undefined, link: customLink = undefined } = options || {};
 
@@ -222,7 +224,7 @@ class AWSAppSyncClient<TCacheShape extends NormalizedCacheObject> extends Apollo
                 };
             });
         });
-        const link = waitForRehydrationLink.concat(customLink || createAppSyncLink({ url, region, auth, complexObjectsCredentials, conflictResolver }));
+        const link = waitForRehydrationLink.concat(customLink || createAppSyncLink({ url, region, auth, complexObjectsCredentials, conflictResolver, resultsFetcherLink = createHttpLink({ uri: url, headers: customHeaders }) }));
 
         const newOptions = {
             ...options,


### PR DESCRIPTION
*Description of changes:*

This change should allow passing a customHeaders argument to createAppSyncClient to easily add headers to requests.

For example, to add an authorization header, instead of doing this :

```
const AppSyncConfig = {
  url:  "url",
  region: "us-east-1",
  auth: {
    type: "API_KEY",
    apiKey: "key"
  }
};

const client = new AWSAppSyncClient(AppSyncConfig, {
  link: createAppSyncLink({
    ...AppSyncConfig,
    resultsFetcherLink: ApolloLink.from([
      setContext((request, previousContext) => ({
        headers: {
          ...previousContext.headers,
          "Authorization": "Bearer 1234"
        }
      })),
      createHttpLink({
        uri: AppSyncConfig.url
      })
    ])
  })
});
```

We could do this : 

```
const AppSyncConfig = {
  url: "url",
  region: "us-east-1",
  auth: {
    type: "API_KEY",
    apiKey: "key",
 customHeaders: {"Authorization" : "Bearer 1234"},
  }
};

const client = new AWSAppSyncClient(AppSyncConfig);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
